### PR TITLE
Changes to run F1 in Linux systems

### DIFF
--- a/F1/__main__.py
+++ b/F1/__main__.py
@@ -1,6 +1,7 @@
 import F1
 import sys
 import json
+import os
 def main():
     if len(sys.argv) < 2:
         print('''
@@ -17,16 +18,19 @@ Usage: python -m F1 <grammar.json>
     with open('vm_ops.s', 'w+') as f:
         print(vm_ops, file=f)
 
-    with open('fuzz.s', 'w+') as f:
+    with open('fuzz.S', 'w+') as f:
         print(fuzz_src, file=f)
 
     with open('main.c', 'w+') as f:
         print(main_src, file=f)
 
-    print('''\
-Next step:
-$ cc -g -Ofast -o fuzzer main.c fuzz.s
-$ rm -f io.x
+    uname = os.uname()
+    print('\nNext step:')
+    if uname.sysname == "Darwin":
+        print('$ cc -g -Ofast -o fuzzer main.c fuzz.S')
+    elif uname.sysname == "Linux":
+        print('$ clang -g -Ofast -mcmodel=medium  -o fuzzer main.c fuzz.S')
+    print('''$ rm -f io.x
 $ ./fuzzer 0 1000 1000
 $ cat io.x
 ''')

--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
 # F1 Fuzzer
 
-This is the F1 Fuzzer described in the paper [Building Fast
-Fuzzers](https://arxiv.org/abs/1911.07707).
+This is the F1 Fuzzer described in the paper [Building Fast Fuzzers](https://arxiv.org/abs/1911.07707).
 
 If you use F1 in a production setting, if you found bugs with it (yay!), or if
 you have any suggestions to share, please let us know – your experience is very
 valuable for us.  Thanks!
+
+
+### List of changes made to the sourcecode to make it run on Linux systems - ###
+- Requires clang as compiler to work in Linux
+- "stdint.h" header included in main.c
+- fuzz\_src is written to fuzz.S instead of fuzz.s
+- Compiled in Linux using "clang -g -Ofast -mcmodel=medium  -o fuzzer main.c fuzz.S"
+  while MacOS compiles using "cc -g -Ofast -o fuzzer main.c fuzz.S"
+- stackp's array size is INT\_MAX/100 in Linux (INT\_MAX in MacOS)
+- out\_region\_initp's arraysize is UINT\_MAX/100 (UINT\_MAX in MacOS)
+- all contents of ".section  __DATA,__data" is moved to ".text" section in vm\_ops.s


### PR DESCRIPTION
Required changes to allow F1 to run in Linux systems. The changes are noted in README. Also added here for the sake of convenience -
- Requires clang as compiler to work in Linux
- "stdint.h" header included in main.c
- fuzz_src is written to fuzz.S instead of fuzz.s
- Compiled in Linux using "clang -g -Ofast -mcmodel=medium -o fuzzer main.c fuzz.S" while MacOS compiles using "cc -g -Ofast -o fuzzer main.c fuzz.S"
- stackp's array size is INT_MAX/100 in Linux (INT_MAX in MacOS)
- out_region_initp's arraysize is UINT_MAX/100 (UINT_MAX in MacOS)
- all contents of ".section __DATA,__data" is moved to ".text" section in vm_ops.s

These changes fixes issues #1, #2, #3 and #4.